### PR TITLE
Use utf-8 encoding when reading/writing to file

### DIFF
--- a/pytest_accept/doctest_plugin.py
+++ b/pytest_accept/doctest_plugin.py
@@ -184,9 +184,9 @@ def pytest_sessionfinish(session, exitstatus):
         # sort by line number
         failures = sorted(failures, key=lambda x: x.test.lineno or 0)
 
-        original = list(path.read_text().splitlines())
+        original = list(path.read_text(encoding="utf-8").splitlines())
         path = path.with_suffix(".py.new") if passed_accept_copy else path
-        with path.open("w+") as file:
+        with path.open("w+", encoding="utf-8") as file:
 
             # TODO: is there cleaner way of doing this interleaving?
 


### PR DESCRIPTION
When attempting to use pytest-accept in https://github.com/pydata/xarray/pull/5950 with my windows 10 machine I got errors like these:
```
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 22168: character maps to <undefined> 'true' is not recognized as an internal or external command, operable program or batch file.
```

Some google answers suggest it's because of encoding differences:
https://stackoverflow.com/questions/49562499/how-to-fix-unicodedecodeerror-charmap-codec-cant-decode-byte-0x9d-in-posit

This PR makes sure utf-8 is used to read/write the files which fixes my particular issue. 
I haven't thought deeper if this may affect anything else though.