### PR TITLE
Remove deprecated pytest param

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -567,4 +567,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8, <4"
-content-hash = "ff2043f90186996a0f78c6bb9e4d9b3badb6b5406bb57e0f7c3f8a149be61d01"
+content-hash = "2431baa7673fc99a7d28f5da8798982986f67bed903a79e33f0aba42f400d85b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ format-jinja = "{% if distance == 0 %}{{ base }}{% else %}{{ base }}.dev{{ dista
 accept = "pytest_accept"
 
 [tool.poetry.dependencies]
-pytest = ">=6"
+pytest = ">=7"
 python = ">=3.8, <4"
 
 [tool.poetry.group.dev.dependencies]
@@ -45,8 +45,11 @@ profile = "black"
 skip_gitignore = true
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules"
+addopts = ["--strict-config", "--strict-markers", "--doctest-modules"]
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS"
+filterwarnings = [
+  "error:::pytest_accept.*",
+]
 pytester_example_dir = "examples"
 testpaths = [
   "pytest_accept",
@@ -58,12 +61,22 @@ requires = ["poetry-core>=1.0.2", "poetry-dynamic-versioning"]
 
 [tool.ruff]
 fix = true
+
+[tool.ruff.lint]
 ignore = [
   # ignores from `flak8`, though possibly ruff doesn't enforce those that
   # conflict with black?
   "E402", # module level import at top — too strict in some cases
   "E501", # line too long - defer to `black`
   "E731", # No lambdas — too strict
+]
+select = [
+  "F", # Pyflakes
+  "E", # Pycodestyle
+  "W",
+  "TID", # flake8-tidy-imports (absolute imports)
+  "I", # isort
+  "UP", # Pyupgrade
 ]
 
 [tool.mypy]

--- a/pytest_accept/doctest_plugin.py
+++ b/pytest_accept/doctest_plugin.py
@@ -28,12 +28,11 @@ failed_doctests: dict[Path, list[DocTestFailure]] = defaultdict(list)
 file_hashes: dict[Path, int] = {}
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(file_path, parent):
     """
     Store the hash of the file so we can check if it changed later
     """
-    path = Path(path)
-    file_hashes[path] = hash(path.read_bytes())
+    file_hashes[file_path] = hash(file_path.read_bytes())
 
 
 @pytest.hookimpl(hookwrapper=True, tryfirst=True)


### PR DESCRIPTION
Bumps pytest requirement to 7, which was released in 2022
