### PR TITLE
Remove isort config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,13 +37,6 @@ ruff = "^0.2.1"
 # Currently causing Windows to break on 3.10
 # pdbpp = "^0.10.3"
 
-[tool.isort]
-default_section = "THIRDPARTY"
-float_to_top = true
-known_first_party = ["pytest-accept"]
-profile = "black"
-skip_gitignore = true
-
 [tool.pytest.ini_options]
 addopts = ["--strict-config", "--strict-markers", "--doctest-modules"]
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL ELLIPSIS"


### PR DESCRIPTION
RIP, one of the original great python tools
