### PR TITLE
Refactor CI workflows for PyPI release and testing

### DIFF
--- a/.github/workflows/pypi-release-test.yaml
+++ b/.github/workflows/pypi-release-test.yaml
@@ -1,29 +1,34 @@
-name: Test release to PyPI
+name: Test Release
 
 on:
   push:
     branches:
       - main
-    # tags:
-    #   - "*"
 
 jobs:
-  release:
+  test-release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
+
       - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Generate test version
         run: |
-          pip install uv
-      - name: Build package
+          # Get current version from pyproject.toml
+          VERSION=$(grep -E "^version = " pyproject.toml | cut -d'"' -f2)
+          # Create a test version with timestamp (PyPI compatible)
+          TEST_VERSION="${VERSION}.dev$(date +%Y%m%d%H%M%S)"
+          echo "TEST_VERSION=$TEST_VERSION" >> $GITHUB_ENV
+          # Update version in pyproject.toml
+          sed -i "s/^version = .*/version = \"$TEST_VERSION\"/" pyproject.toml
+
+      - name: Build with test version
         run: |
-          uv venv
+          uv python install 3.13
           uv build
+
       - name: Publish to TestPyPI
         run: |
           uv publish --token ${{ secrets.PYPI_TEST_TOKEN }} --publish-url https://test.pypi.org/legacy/

--- a/.github/workflows/pypi-release.yaml
+++ b/.github/workflows/pypi-release.yaml
@@ -1,31 +1,25 @@
-name: Release to PyPI
+name: Release
 
 on:
-  push:
-    tags:
-      - "*"
-    # This is disabled since it conflicts when a commit is both on main and a tag.
-    # # Will only release a pre-release version without a tag.
-    # # branches:
-    # #   - main
+  release:
+    types: [published]
 
 jobs:
-  release:
+  pypi:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.9
+
       - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Install Python and build
         run: |
-          pip install uv
-      - name: Build package
-        run: |
-          uv venv
+          uv python install 3.13
           uv build
+
       - name: Publish to PyPI
-        run: |
-          uv publish --token ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,9 +2,9 @@
 authors = [{ name = "Maximilian Roos", email = "m@maxroos.com" }]
 dependencies = ["astor>=0.8.1", "pytest>=7"]
 requires-python = ">=3.9, <4"
-license = { text = "Apache-2.0" }
+license = "Apache-2.0"
 readme = "README.md"
-dynamic = ["version"]
+version = "0.1.13"
 name = "pytest-accept"
 urls = { homepage = "https://github.com/max-sixty/pytest-accept", repository = "https://github.com/max-sixty/pytest-accept" }
 
@@ -21,11 +21,14 @@ filterwarnings = ["error:::pytest_accept.*"]
 pytester_example_dir = "examples"
 testpaths = ["pytest_accept"]
 
-[tool.setuptools_scm]
-fallback_version = "9999"
 
 [build-system]
-requires = ["setuptools>=61.0", "setuptools-scm>=7"]
+requires = ["uv_build>=0.7.19,<0.8.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = "pytest_accept"
+module-root = ""
 
 [tool.ruff]
 fix = true

--- a/pytest_accept/__init__.py
+++ b/pytest_accept/__init__.py
@@ -1,3 +1,10 @@
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pytest-accept")
+except PackageNotFoundError:
+    __version__ = "unknown"
+
 from .doctest_plugin import (
     pytest_addoption,
     pytest_collect_file,
@@ -6,10 +13,11 @@ from .doctest_plugin import (
     pytest_sessionfinish,
 )
 
-# Note that pluginsn need to be listed here in order for pytest to pick them up when
+# Note that plugins need to be listed here in order for pytest to pick them up when
 # this package is installed.
 
 __all__ = [
+    "__version__",
     "pytest_runtest_makereport",
     "pytest_sessionfinish",
     "pytest_addoption",

--- a/pytest_accept/tests/test_doctest.py
+++ b/pytest_accept/tests/test_doctest.py
@@ -58,20 +58,15 @@ def add_example():
     ...
 
     >>> result = pytester.runpytest("--doctest-modules", "--accept")
-    ===... test session starts ...===...
-    platform ... -- Python ..., pytest-..., pluggy-...
-    rootdir: ...
-    plugins: accept-...
+    ============================= test session starts ==============================
+    platform darwin -- Python 3.11.13, pytest-8.3.5, pluggy-1.5.0
+    rootdir: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/pytest-of-maximilian/pytest-4801/pytest_accept.tests.test_doctest.add_example0
+    plugins: accept-0.1.13.dev30
     collected 1 item
     <BLANKLINE>
-    add.py ...                                                               ...[100%]
+    add.py .                                                                 [100%]
     <BLANKLINE>
-    ===... warnings summary ...===...
-    ...PytestAssertRewriteWarning: Module already imported so cannot be rewritten: pytest_accept
-    ...
-    <BLANKLINE>
-    -- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
-    ===... 1 passed, 1 warning in ... ...===...
+    ============================== 1 passed in 0.00s ===============================
 
     """
 

--- a/pytest_accept/tests/test_doctest.py
+++ b/pytest_accept/tests/test_doctest.py
@@ -59,14 +59,14 @@ def add_example():
 
     >>> result = pytester.runpytest("--doctest-modules", "--accept")
     ============================= test session starts ==============================
-    platform darwin -- Python 3.11.13, pytest-8.3.5, pluggy-1.5.0
-    rootdir: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/pytest-of-maximilian/pytest-4801/pytest_accept.tests.test_doctest.add_example0
-    plugins: accept-0.1.13.dev30
+    platform ... -- Python ..., pytest-..., pluggy-...
+    rootdir: ...
+    plugins: accept-...
     collected 1 item
     <BLANKLINE>
     add.py .                                                                 [100%]
     <BLANKLINE>
-    ============================== 1 passed in 0.00s ===============================
+    ============================== 1 passed in ...s ===============================
 
     """
 

--- a/uv.lock
+++ b/uv.lock
@@ -312,6 +312,7 @@ wheels = [
 
 [[package]]
 name = "pytest-accept"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "astor" },


### PR DESCRIPTION
Updates the PyPI release workflow to trigger on `release` events and use `pypa/gh-action-pypi-publish`.
The test release workflow now generates a timestamped test version and uses `astral-sh/setup-uv`.
Removes `setuptools-scm` and sets a static version in `pyproject.toml`, with `uv_build` as the build backend.
Adds `__version__` to `pytest_accept/__init__.py` for version retrieval.
Updates doctest output in `test_doctest.py` to reflect changes in pytest output.

Co-authored-by: Claude <no-reply@anthropic.com>
