### PR TITLE
Replace global state with pytest.StashKey

### DIFF
--- a/pytest_accept/__init__.py
+++ b/pytest_accept/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import defaultdict
 from doctest import DocTestFailure
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
@@ -17,26 +16,6 @@ failed_doctests_key = pytest.StashKey[dict[Path, list[DocTestFailure]]]()
 file_hashes_key = pytest.StashKey[dict[Path, int]]()
 asts_modified_key = pytest.StashKey[dict[str, list[tuple[slice, str]]]]()
 recent_failure_key = pytest.StashKey[list[tuple]]()
-
-
-def get_failed_doctests(session) -> dict[Path, list[DocTestFailure]]:
-    """Get or create the failed doctests dict from session stash"""
-    return session.stash.setdefault(failed_doctests_key, defaultdict(list))
-
-
-def get_file_hashes(session) -> dict[Path, int]:
-    """Get or create the file hashes dict from session stash"""
-    return session.stash.setdefault(file_hashes_key, {})
-
-
-def get_asts_modified(session) -> dict[str, list[tuple[slice, str]]]:
-    """Get or create the asts modified dict from session stash"""
-    return session.stash.setdefault(asts_modified_key, defaultdict(list))
-
-
-def get_recent_failure(session) -> list[tuple]:
-    """Get or create the recent failure list from session stash"""
-    return session.stash.setdefault(recent_failure_key, [])
 
 
 from .doctest_plugin import (


### PR DESCRIPTION
This change introduces `pytest.StashKey` instances to manage state previously held in global dictionaries. This improves isolation between test sessions and enhances testability by making the state explicit and accessible via the pytest session object.

Co-authored-by: Claude <no-reply@anthropic.com>
