### PR TITLE
Update prettier pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,13 +27,12 @@ repos:
       - id: check-yaml
       - id: debug-statements
       - id: mixed-line-ending
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.6.2
     hooks:
       - id: prettier
         additional_dependencies:
           - prettier
-          - prettier-plugin-go-template
   - repo: https://github.com/crate-ci/typos
     rev: v1.27.3
     hooks:


### PR DESCRIPTION
Updates the prettier pre-commit hook to use a different repository and version.
Removes `prettier-plugin-go-template` from additional dependencies.

Co-authored-by: Claude <no-reply@anthropic.com>
