### PR TITLE
Use ExceptHandler.name instead of deprecated "identifier"

### DIFF
--- a/pytest_accept/assert_plugin.py
+++ b/pytest_accept/assert_plugin.py
@@ -128,7 +128,7 @@ def _patch_assertion_rewriter():
             handlers=[
                 ast.ExceptHandler(
                     expr=AssertionError,
-                    identifier="__pytest_accept_e",
+                    name="__pytest_accept_e",
                     body=_ASSERTION_HANDLER,
                 )
             ],


### PR DESCRIPTION
This resolves the following deprecation warning:

    .../pytest_accept/assert_plugin.py:129: DeprecationWarning:
    ExceptHandler.__init__ got an unexpected keyword argument
    'identifier'. Support for arbitrary keyword arguments is deprecated
    and will be removed in Python 3.15.

Related to #260.