### PR TITLE
Fix handling of != and exceptions in assert plugin

### DIFF
--- a/pytest_accept/tests/test_assert_plugin.py
+++ b/pytest_accept/tests/test_assert_plugin.py
@@ -11,6 +11,29 @@ def test_basic(pytester):
         assert f.read() == test_contents.replace("1 == 3", "1 == 1")
 
 
+def test_neq(pytester):
+    test_contents = "def test_x():\n    assert 1 != 1\n"
+    path = pytester.makepyfile(test_contents)
+    result = pytester.runpytest("--accept-copy")
+    result.assert_outcomes(failed=1)
+    assert "FAILED test_neq.py::test_x - assert 1 != 1" in result.outlines
+
+    assert not os.path.exists(str(path) + ".new")
+
+
+def test_exception(pytester):
+    test_contents = "def test_x():\n    assert [][1] == 0\n"
+    path = pytester.makepyfile(test_contents)
+    result = pytester.runpytest("--accept-copy")
+    result.assert_outcomes(failed=1)
+    assert (
+        "FAILED test_exception.py::test_x - IndexError: list index out of range"
+        in result.outlines
+    )
+
+    assert not os.path.exists(str(path) + ".new")
+
+
 def test_too_complex(pytester):
     test_contents = "import random\ndef test_x():\n    assert 10 == random.random()\n"
     path = pytester.makepyfile(test_contents)

--- a/pytest_accept/tests/test_assertion_filtering.py
+++ b/pytest_accept/tests/test_assertion_filtering.py
@@ -34,7 +34,7 @@ def test_operators():
     path = pytester.makepyfile(test_contents)
 
     result = pytester.runpytest("--accept-copy")
-    result.assert_outcomes(passed=1)
+    result.assert_outcomes(failed=1)
 
     new_path = path.parent / (path.name + ".new")
     assert new_path.exists()


### PR DESCRIPTION
This fixes two issues in the assert plugin shadowing failures when:
- an exception is raised in an `assert` statement (e.g. a `KeyError` as in added test), and,
- an `assert` statement with a `!=` was failing.

This was because the early conditions in `__handle_failed_assertion_impl()` should not make the loop break, meaning our patched rewriter was acting, but instead continue in order to finally re-raise the failed assertion.

Also fix the unexpected "passed" instead of a "failed" in test_non_equality_operators_not_rewritten().