### PR TITLE
Release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+## [0.2.2] - 2025-01-19
+
+### Fixed
+
+- Fixed compatibility with Python 3.13+ by using `ExceptHandler.name` instead of
+  deprecated `identifier` attribute (#261) - @dlax
+- Fixed handling of `!=` operators and exceptions in assert plugin (#262) -
+  @dlax
+- Fixed compatibility with environments that don't have pytest-xdist installed
+  (#259)
+
+## [0.2.1] - 2024-11-17
+
+### Fixed
+
+- Re-release of 0.2.0 to fix PyPI publishing workflow issue
+- No functional changes from 0.2.0
+
+## [0.2.0] - 2024-11-17
+
+### Added
+
+- **Major Feature**: pytest-accept now supports standard `assert` tests as well
+  as doctests! (#242)
+  - The plugin can now automatically update assertion values in regular pytest
+    test functions
+  - Works alongside the existing doctest functionality
+  - Thanks to @untitaker for the inspiration
+
+For earlier changes, please see the git history.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ dependencies = ["astor>=0.8.1", "pytest>=7"]
 requires-python = ">=3.9, <4"
 license = "Apache-2.0"
 readme = "README.md"
-version = "0.2.1"
+version = "0.2.2"
 name = "pytest-accept"
 urls = { homepage = "https://github.com/max-sixty/pytest-accept", repository = "https://github.com/max-sixty/pytest-accept" }
 


### PR DESCRIPTION
## Summary
- Prepare for v0.2.2 patch release
- Fix compatibility issues with Python 3.13+ and environments without pytest-xdist
- Add comprehensive CHANGELOG.md

## Changes
See [CHANGELOG.md](https://github.com/max-sixty/pytest-accept/blob/release/CHANGELOG.md#022---2025-01-19) for full details.

### Fixed
- Fixed compatibility with Python 3.13+ by using `ExceptHandler.name` instead of deprecated `identifier` attribute (#261) - @dlax
- Fixed handling of `!=` operators and exceptions in assert plugin (#262) - @dlax
- Fixed compatibility with environments that don't have pytest-xdist installed (#259)

## Test plan
- [x] All tests pass locally
- [x] Pre-commit hooks pass
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)