### PR TITLE
chore: modernize ruff hook ID from legacy alias

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     rev: v0.14.9
     hooks:
       - id: ruff-format
-      - id: ruff
+      - id: ruff-check
   - repo: local
     hooks:
       - id: ty


### PR DESCRIPTION
## Summary
- Replace `ruff` with `ruff-check` hook ID to eliminate the "ruff (legacy alias)" warning

## Test plan
- [ ] CI passes with the updated hook ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)