### PR TITLE
Release 0.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.2.4] - 2026-06-11
+
+### Fixed
+
+- Include the LICENSE file in sdists and wheels (#310) - @isuruf
+
 ## [0.2.3] - 2026-02-28
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.9, <4"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = "README.md"
-version = "0.2.3"
+version = "0.2.4"
 name = "pytest-accept"
 urls = { homepage = "https://github.com/max-sixty/pytest-accept", repository = "https://github.com/max-sixty/pytest-accept" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9, <4"
 resolution-markers = [
     "python_full_version >= '3.10'",
@@ -196,7 +196,7 @@ wheels = [
 
 [[package]]
 name = "pytest-accept"
-version = "0.2.2"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "astor" },


### PR DESCRIPTION
Version bump and changelog for 0.2.4 — the only user-facing change since 0.2.3 is including the LICENSE file in sdists and wheels (#310). Also syncs uv.lock, which was stale at 0.2.2.

> _This was written by Claude Code on behalf of max_

🤖 Generated with [Claude Code](https://claude.com/claude-code)