### PR TITLE
Release 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.3.0] - 2026-06-11
+
+### Changed
+
+- Dropped support for Python 3.9, which reached end-of-life in October 2025
+  (#312). Python 3.10+ is now required.
+
 ## [0.2.4] - 2026-06-11
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.10, <4"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = "README.md"
-version = "0.2.4"
+version = "0.3.0"
 name = "pytest-accept"
 urls = { homepage = "https://github.com/max-sixty/pytest-accept", repository = "https://github.com/max-sixty/pytest-accept" }
 

--- a/uv.lock
+++ b/uv.lock
@@ -164,7 +164,7 @@ wheels = [
 
 [[package]]
 name = "pytest-accept"
-version = "0.2.4"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "astor" },


### PR DESCRIPTION
Version bump and changelog for 0.3.0 — the headline change is dropping Python 3.9 (#312), which is why this is a minor bump rather than a patch.

> _This was written by Claude Code on behalf of max_

🤖 Generated with [Claude Code](https://claude.com/claude-code)